### PR TITLE
鳥小屋春の進捗祭り

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN cd /etc/app; bundle update
 EXPOSE 80
 EXPOSE 8080
 
-CMD nginx && cd /etc/app && bundle exec rake db:migrate && bundle exec ruby web-frontend.rb
+CMD cd /etc/proc_profiles && ./generate.sh -l /etc/apt_repository/available_package_table && nginx && cd /etc/app && bundle exec rake db:migrate && bundle exec ruby web-frontend.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ diffutils texinfo flex guile-2.0-dev autogen tcl expect dejagnu gperf gettext au
 libreadline6 libreadline6-dev libc6-dev-i386 \
 gauche bison
 
+RUN cd /usr/bin; wget http://stedolan.github.io/jq/download/linux64/jq; chmod 755 jq
+
 RUN cd /etc; git clone https://github.com/yutopp/torigoya_package_scripts.git package_scripts
 
 RUN gem install thin bundler fpm --no-rdoc --no-ri
@@ -23,6 +25,7 @@ ADD nginx.conf /etc/nginx/nginx.conf
 
 ADD app /etc/app
 ADD config.in_docker.yml /etc/app/config.yml
+ADD proc_profiles /etc/proc_profiles
 RUN cd /etc/app; bundle update
 
 EXPOSE 80

--- a/app/src/builder.rb
+++ b/app/src/builder.rb
@@ -189,10 +189,10 @@ module Torigoya
       #
       def make_packages_list
         sd = platform_package_script_dir()
-        glob_p = "#{Shellwords.escape sd}/*.#{@platform_config[:ext]}"
+        glob_p = "#{Shellwords.escape sd}/**/*.#{@platform_config[:ext]}"
         packages_list = Dir::glob(glob_p)
-                        .map {|f| File.basename f}
-                        .select {|f| f[0] != '_'}
+                        .select {|f| (File.basename f)[0] != '_'}
+                        .map {|f| f[sd.length+1..f.length]}
 
         return packages_list.sort!
       end

--- a/app/web-frontend.rb
+++ b/app/web-frontend.rb
@@ -260,29 +260,14 @@ end
 #
 # ========================================
 #
-get '/packaging_and_install/:name' do
+get '/packaging_and_install/*' do |name|
   if login?
     begin
-      name = params['name']
-      status = install(name, false)
-
-      stream_status(status)
-
-    rescue => e
-      return exception_raised(e)
-    end
-
-  else
-    return unauthed_error()
-  end
-end
-
-#
-get '/packaging_and_install/:name/reuse' do
-  if login?
-    begin
-      name = params['name']
-      status = install(name, true)
+      if name[name.length-6, 6] == "/reuse"
+        status = install(name[0, name.length-6], true)
+      else
+        status = install(name, false)
+      end
 
       stream_status(status)
 
@@ -300,29 +285,14 @@ end
 #
 # ========================================
 #
-get '/packaging_and_install_lazy/:name' do
+get '/packaging_and_install_lazy/*' do |name|
   if login?
     begin
-      name = params['name']
-      add_to_install_task(name, false)
-
-      redirect '/'
-
-    rescue => e
-      return exception_raised(e)
-    end
-
-  else
-    return unauthed_error()
-  end
-end
-
-#
-get '/packaging_and_install_lazy/:name/reuse' do
-  if login?
-    begin
-      name = params['name']
-      add_to_install_task(name, true)
+      if name[name.length-6, 6] == "/reuse"
+        add_to_install_task(name[0, name.length-6], true)
+      else
+        add_to_install_task(name, false)
+      end
 
       redirect '/'
 

--- a/docker.run.sh
+++ b/docker.run.sh
@@ -11,9 +11,6 @@ echo "Torigoya factory: a port of files    : 80"
 echo "Torigoya factory: a port of frontend : 8080"
 
 cp -r ../torigoya_proc_profiles -T proc_profiles
-cd proc_profiles
-./generate.sh -l ${APT_REPOSITORY_PATH}/available_package_table
-cd ..
 
 ./docker.stop.sh &&
 ./docker.build.sh &&

--- a/docker.run.sh
+++ b/docker.run.sh
@@ -10,6 +10,11 @@ echo "Torigoya factory: packages path      : $PACKAGES_PATH"
 echo "Torigoya factory: a port of files    : 80"
 echo "Torigoya factory: a port of frontend : 8080"
 
+cp -r ../torigoya_proc_profiles -T proc_profiles
+cd proc_profiles
+./generate.sh -l ${APT_REPOSITORY_PATH}/available_package_table
+cd ..
+
 ./docker.stop.sh &&
 ./docker.build.sh &&
 echo "start container => " &&
@@ -24,3 +29,5 @@ sudo docker run \
     --name torigoya_factory \
     --detach=true \
     torigoya/factory
+
+rm -rf proc_profiles


### PR DESCRIPTION
自分用の忘備録的な意味合いも含めて軽く説明．コード読むときの足しにでもしてください．

---
### 65bd1a5 "change package_scripts to directory separable"

package_scriptsがいい加減散らかってきたので，ディレクトリ分けしても認識するようにしました．
ホントは表示もいい感じに横にずらしたりしたかったのですが，データの持ち方的にめんどくさそうだったのでやめました．
結局工場では縦にずらずらと並びます．
[torigoya_package_scripts/89df6db](https://github.com/yutopp/torigoya_package_scripts/commit/89df6db6bcbb42830a7d7db993c934ea2c9f824a)と連動しています．
### a192e99 "add proc_profiles for build with the factory made toolchains"

/etc/proc_profilesに工場製ツールチェインを工場内で使うためのproc_profilesを導入，さらにシェル上でのjsonパースのためにjqをインストールする設定．
[torigoya_package_scripts/9a3c357](https://github.com/yutopp/torigoya_package_scripts/commit/9a3c3579964a57b3fed199172d2ae9b5f2f7cdeb)と連動しています．
### 438bd1a "fix issue that can't generate proc_profiles in host environment without ruby"

前のコミット，Dockerの動作のタイミング知らんかったのであんな感じで書いてましたが，あれだとCoreOSみたいなruby環境のないホストでdocker.run.shする時にproc_profileの生成が出来ないと怒られそうだったので，ゲストで生成させるように変更．
